### PR TITLE
Add more cooldown info to BP library function

### DIFF
--- a/Source/KaosGASUtilities/Private/BehaviourTrees/KaosBTDecorator_IsAbilityOnCooldown.cpp
+++ b/Source/KaosGASUtilities/Private/BehaviourTrees/KaosBTDecorator_IsAbilityOnCooldown.cpp
@@ -69,7 +69,8 @@ bool UKaosBTDecorator_IsAbilityOnCooldown::CalculateRawConditionValue(UBehaviorT
 		return false;
 	}
 
-	return UKaosUtilitiesBlueprintLibrary::IsAbilityOnCooldownWithAllTags(ASC, FGameplayTagContainer(AbilityTag));
+	float TimeRemaining, Duration; // Not used, but needed for the function
+	return UKaosUtilitiesBlueprintLibrary::IsAbilityOnCooldownWithAllTags(ASC, FGameplayTagContainer(AbilityTag), TimeRemaining, Duration);
 }
 
 FString UKaosBTDecorator_IsAbilityOnCooldown::GetStaticDescription() const

--- a/Source/KaosGASUtilities/Public/KaosUtilitiesBlueprintLibrary.h
+++ b/Source/KaosGASUtilities/Public/KaosUtilitiesBlueprintLibrary.h
@@ -90,7 +90,7 @@ public:
 	 * has A.1 and C.1, it will return false.
 	 */
 	UFUNCTION(BlueprintCallable, Category="KaosGAS")
-	static bool IsAbilityOnCooldownWithAllTags(UAbilitySystemComponent* AbilitySystemComponent, const FGameplayTagContainer& GameplayAbilityTags);
+	static bool IsAbilityOnCooldownWithAllTags(UAbilitySystemComponent* AbilitySystemComponent, const FGameplayTagContainer& GameplayAbilityTags, float& TimeRemaining, float& Duration);
 
 	/**
 	 * Returns true if we can activate ability by the supplied class.


### PR DESCRIPTION
Added the boilerplate from GASDocumentation which finds the cooldown time and duration into the `IsAbilityOnCooldownWithAllTags` function. I figure it best to tie it into this function rather than make a new one that simply invokes this function as a checker.